### PR TITLE
Fix V3013

### DIFF
--- a/DotNetToolBox/ExtensionMethods.cs
+++ b/DotNetToolBox/ExtensionMethods.cs
@@ -115,7 +115,7 @@ namespace DotNetToolBox
 
         public static bool ContainsALowerCaseCharacter(this string obj)
         {
-            return obj.ContainsUpperCaseCharacters(1);
+            return obj.ContainsLowerCaseCharacters(1);
         }
 
         public static bool ContainsLowerCaseCharacters(this string obj, int minimumNumberofLowerCaseCharacters)


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

-  It is odd that the body of 'ContainsAnUpperCaseCharacter' function is fully equivalent to the body of 'ContainsALowerCaseCharacter' function. DotNetToolBox ExtensionMethods.cs 106


I think this a copy and paste error 